### PR TITLE
fix: @react-leaflet/core dependency and events is required

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,11 +34,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -49,7 +49,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -63,4 +63,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "comlink": "^4.4.2",
         "escape-html": "^1.0.3",
+        "events": "^3.3.0",
         "p-queue": "^8.0.1"
       },
       "devDependencies": {
@@ -44,6 +45,7 @@
         "vite-plugin-externalize-deps": "^0.8.0"
       },
       "peerDependencies": {
+        "@react-leaflet/core": "^2.1.0 || ^3.0.0",
         "leaflet": "^1.9.4",
         "pouchdb": "^9.0.0",
         "pouchdb-browser": "^9.0.0",
@@ -3498,6 +3500,15 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -46,11 +46,13 @@
     "pouchdb-browser": "^9.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
-    "react-leaflet": "^4.2.1 || ^5.0.0"
+    "react-leaflet": "^4.2.1 || ^5.0.0",
+    "@react-leaflet/core": "^2.1.0 || ^3.0.0"
   },
   "dependencies": {
     "comlink": "^4.4.2",
     "escape-html": "^1.0.3",
+    "events": "^3.3.0",
     "p-queue": "^8.0.1"
   },
   "devDependencies": {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,3 +2,5 @@ export * from './pouchdb-tilelayer';
 export * from './ReactPouchDBTileLayer';
 import { ReactPouchDBTileLayer } from './ReactPouchDBTileLayer';
 export default ReactPouchDBTileLayer;
+
+window.global ||= window;


### PR DESCRIPTION
fix: @react-leaflet/core dependency and `events` is required (https://github.com/pouchdb/pouchdb/issues/8989)